### PR TITLE
Make parallel cargo installable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/mmstick/parallel"
 keywords = ["cli", "parallel", "cpu", "load", "balancer"]
 readme = "README.md"
 
+[[bin]]
+name = "parallel"
+test = false
+
 [dependencies]
 num_cpus = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Parallel: A Command-line CPU Load Balancer Written in Rust
 This is an attempt at recreating the functionality of [GNU Parallel](https://www.gnu.org/software/parallel/) in Rust under a MIT license. The end goal will be to support much of the functionality of `GNU Parallel` and then to extend the functionality further for the next generation of command-line utilities written in Rust.
 
+## Installation
+
+```sh
+git clone https://github.com/mmstick/parallel.git && cd parallel
+cargo install
+```
+
 ## Benchmark Comparison to GNU Parallel
 
 Here are some benchmarks from an i5-2410M laptop running Ubuntu 16.04.


### PR DESCRIPTION
I have added an `bin` target to `Cargo.toml` to make `parallel` installable through `cargo install`.
Note that you should release this crate on `crates.io` because otherwise users have to clone the repo before they can install it.
This PR also adds installation instructions to the `README.md`.